### PR TITLE
Strip image metadata from generated thumbnails

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -128,7 +128,7 @@ impl<'a> CastImpl<'a> {
         device.connection.connect("receiver-0").ok()?;
         let def = CastDeviceApp::DefaultMediaReceiver;
         let app = device.receiver.launch_app(&def).ok()?;
-        device.connection.connect(app.transport_id.as_ref()).ok()?;
+        device.connection.connect(&app.transport_id[..]).ok()?;
         let status = device.receiver.get_status().ok()?;
         println!("Status {:?}", status);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,6 +344,9 @@ fn generate_thumbnail(cache_dir: &str, album_id: AlbumId, filename: &str) -> cla
             // pixel-perfect on a high-DPI display, or on a mobile phone.
             .args(&["-distort", "Resize", "140x140!"])
             .args(&["-colorspace", "sRGB"])
+            // Remove EXIF metadata, including the colour profile if there was
+            // any -- we convert to sRGB anyway.
+            .args(&["-strip"])
             .args(&["-quality", "95"])
             .arg(out_fname)
             .stdin(Stdio::piped())


### PR DESCRIPTION
Embedded cover art can contain image metadata, which is not useful in thumbnails, and unnecessarily increases the amount of data to transfer to load the library browser. Pass `-strip` to Imagemagick to remove this metadata.