### PR TITLE
Make album id a prefix of the track id, shrink track struct

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,13 @@ Musium versions are named `MAJOR.MINOR.PATCH`.
    or a migration of the database).
  * The patch version is bumped for bugfixes and other small changes.
 
+## Unreleased
+
+ * **Breaking:** Album ids are now 52 bits instead of 64 bit. This ensures that
+   album ids are prefixes of track ids, which unlocks a few optimizations and
+   simplifications. Unfortunately, this means that existing databases and
+   listens are no longer valid. To migrate, use `tools/migrate_album_ids.py`.
+
 ## 0.12.0
 
 Released 2023-05-06.

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,11 @@
           name = "musium";
           version = builtins.substring 0 8 self.lastModifiedDate;
           pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python3.withPackages (ps: [
+            ps.scipy
+            ps.numpy
+            ps.matplotlib
+          ]);
         in
           rec {
             devShells.default = pkgs.mkShell {
@@ -32,6 +37,7 @@
                 pkgs.purescript
                 pkgs.rustup
                 pkgs.sqlite
+                python
                 squiller.packages.${system}.default
               ]
               ++ packages.default.nativeBuildInputs

--- a/src/build.rs
+++ b/src/build.rs
@@ -831,9 +831,6 @@ impl BuildMetaIndex {
 
         let track = Track {
             file_id: file_id,
-            album_id: album_id,
-            disc_number: disc_number,
-            track_number: track_number,
             title: StringRef(title),
             artist: StringRef(track_artist),
             duration_seconds: file.duration_seconds as u16,

--- a/src/history.rs
+++ b/src/history.rs
@@ -43,14 +43,14 @@ pub fn main(
             PlaybackEvent::Started(queue_id, track_id) => {
                 let index = index_var.get();
                 let track = index.get_track(track_id).unwrap();
-                let album = index.get_album(track.album_id).unwrap();
+                let album = index.get_album(track_id.album_id()).unwrap();
                 let album_artists = index.get_album_artists(album.artist_ids);
                 let listen = Listen {
                     started_at: &now_str[..],
                     file_id: track.file_id.0,
                     queue_id: queue_id.0 as i64,
                     track_id: track_id.0 as i64,
-                    album_id: track.album_id.0 as i64,
+                    album_id: track_id.album_id().0 as i64,
                     // We record only the first album artist, to keep the
                     // structure of the table simple.
                     album_artist_id: album_artists[0].0 as i64,
@@ -59,8 +59,8 @@ pub fn main(
                     track_artist: index.get_string(track.artist),
                     album_artist: index.get_string(album.artist),
                     duration_seconds: track.duration_seconds as i64,
-                    track_number: track.track_number as i64,
-                    disc_number: track.disc_number as i64,
+                    track_number: track_id.track_number() as i64,
+                    disc_number: track_id.disc_number() as i64,
                 };
                 let mut tx = db.begin()?;
                 let result = db::insert_listen_started(&mut tx, listen)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ use std::path::Path;
 use crate::build::{AlbumArtistsDeduper, BuildMetaIndex, BuildError};
 use crate::error::{Error, Result};
 use crate::prim::{ArtistId, Artist, AlbumArtistsRef, AlbumId, Album, TrackId, Track, Lufs, StringRef, FilenameRef};
+use crate::prim::{ArtistWithId, AlbumWithId, TrackWithId};
 use crate::string_utils::StringDeduper;
 use crate::word_index::MemoryWordIndex;
 
@@ -84,16 +85,16 @@ pub trait MetaIndex {
     fn get_album_artists(&self, range: AlbumArtistsRef) -> &[ArtistId];
 
     /// Return all tracks that are part of the album.
-    fn get_album_tracks(&self, id: AlbumId) -> &[(TrackId, Track)];
+    fn get_album_tracks(&self, id: AlbumId) -> &[TrackWithId];
 
     /// Return all tracks, ordered by id.
-    fn get_tracks(&self) -> &[(TrackId, Track)];
+    fn get_tracks(&self) -> &[TrackWithId];
 
     /// Return all albums, ordered by id.
-    fn get_albums(&self) -> &[(AlbumId, Album)];
+    fn get_albums(&self) -> &[AlbumWithId];
 
     /// Return all album artists, ordered by id.
-    fn get_artists(&self) -> &[(ArtistId, Artist)];
+    fn get_artists(&self) -> &[ArtistWithId];
 
     /// Look up an artist by id.
     fn get_artist(&self, _: ArtistId) -> Option<&Artist>;
@@ -181,9 +182,9 @@ impl Bookmarks {
 }
 
 pub struct MemoryMetaIndex {
-    artists: Vec<(ArtistId, Artist)>,
-    albums: Vec<(AlbumId, Album)>,
-    tracks: Vec<(TrackId, Track)>,
+    artists: Vec<ArtistWithId>,
+    albums: Vec<AlbumWithId>,
+    tracks: Vec<TrackWithId>,
 
     // Per artist, all albums, ordered by ascending release date.
     albums_by_artist: Vec<(ArtistId, AlbumId)>,
@@ -210,19 +211,19 @@ pub struct MemoryMetaIndex {
 /// binary search. Albums for a single artist are ordered by ascending release
 /// date.
 fn build_albums_by_artist_index(
-    albums: &[(AlbumId, Album)],
+    albums: &[AlbumWithId],
     album_artists: &AlbumArtistsDeduper,
 ) -> Vec<(ArtistId, AlbumId)> {
     // Add a bit of headroom, most albums have one artist, but some albums have
     // multiple.
     let mut entries_with_date = Vec::with_capacity(albums.len() * 40 / 32);
 
-    for &(album_id, ref album) in albums {
-        for album_artist_id in album_artists.get(album.artist_ids) {
+    for kv in albums {
+        for album_artist_id in album_artists.get(kv.album.artist_ids) {
             entries_with_date.push((
                 *album_artist_id,
-                album_id,
-                album.original_release_date,
+                kv.album_id,
+                kv.album.original_release_date,
             ));
         }
     }
@@ -243,9 +244,9 @@ fn build_albums_by_artist_index(
 impl MemoryMetaIndex {
     /// Convert the builder into a memory-backed index.
     fn new(builder: &BuildMetaIndex) -> MemoryMetaIndex {
-        let mut artists: Vec<(ArtistId, Artist)> = Vec::with_capacity(builder.artists.len());
-        let mut albums: Vec<(AlbumId, Album)> = Vec::with_capacity(builder.albums.len());
-        let mut tracks: Vec<(TrackId, Track)> = Vec::with_capacity(builder.tracks.len());
+        let mut artists: Vec<ArtistWithId> = Vec::with_capacity(builder.artists.len());
+        let mut albums: Vec<AlbumWithId> = Vec::with_capacity(builder.albums.len());
+        let mut tracks: Vec<TrackWithId> = Vec::with_capacity(builder.tracks.len());
         let mut album_artists = AlbumArtistsDeduper::new();
         let mut strings = StringDeduper::new();
         let mut filenames = Vec::new();
@@ -263,20 +264,18 @@ impl MemoryMetaIndex {
             filenames.push(builder.filenames[track.filename.0 as usize].clone());
             track.filename = FilenameRef(filenames.len() as u32 - 1);
 
-            tracks.push((id, track));
+            tracks.push(TrackWithId { track_id: id, track });
         }
 
-        // There is no easy way in Rust to guarantee that the tracks buffer is
-        // aligned (we could define a custom struct instead of the tuple, but
-        // that is rather invasive), but the allocator will give us an aligned
-        // buffer anyway at this size class. Confirm that.
-        // TODO: Apparently, this can be violated after all, I am getting
-        // 16-byte alignment instead of 32-byte alignment :/
+        // This should be enforced by the repr(align), but confirm this at
+        // runtime to double check that I am using the right types.
         let tracks_addr = tracks[..].as_ptr() as *const u8;
         let align_off = tracks_addr.align_offset(32);
-        if align_off != 0 {
-            println!("Warning: Tracks table is not aligned to 32 bytes, this may impact performance.");
-        }
+        assert_eq!(
+            align_off,
+            0,
+            "Tracks table must align to 32 bytes so elements do not straddle cache lines."
+        );
 
         for (id, album) in builder.albums.iter() {
             let (id, mut album) = (*id, album.clone());
@@ -310,7 +309,7 @@ impl MemoryMetaIndex {
                 album.first_seen = album.first_seen.min(*first_listen);
             }
 
-            albums.push((id, album));
+            albums.push(AlbumWithId { album_id: id, album });
         }
 
         for (id, artist) in builder.artists.iter() {
@@ -323,7 +322,7 @@ impl MemoryMetaIndex {
                 strings.insert(builder.strings.get(artist.name_for_sort.0))
             );
 
-            artists.push((id, artist));
+            artists.push(ArtistWithId { artist_id: id, artist });
         }
 
         strings.upgrade_quotes();
@@ -334,9 +333,9 @@ impl MemoryMetaIndex {
         );
 
         MemoryMetaIndex {
-            artist_bookmarks: Bookmarks::new(artists.iter().map(|p| (p.0).0)),
-            album_bookmarks: Bookmarks::new(albums.iter().map(|p| p.0.for_bookmark())),
-            track_bookmarks: Bookmarks::new(tracks.iter().map(|p| (p.0).0)),
+            artist_bookmarks: Bookmarks::new(artists.iter().map(|p| p.artist_id.0)),
+            album_bookmarks: Bookmarks::new(albums.iter().map(|p| p.album_id.for_bookmark())),
+            track_bookmarks: Bookmarks::new(tracks.iter().map(|p| p.track_id.0)),
             albums_by_artist_bookmarks: Bookmarks::new(albums_by_artist.iter().map(|p| (p.0).0)),
             artists: artists,
             albums: albums,
@@ -431,20 +430,20 @@ impl MetaIndex for MemoryMetaIndex {
     fn get_track(&self, id: TrackId) -> Option<&Track> {
         let slice = self.track_bookmarks.range(&self.tracks[..], id.0);
         slice
-            .binary_search_by_key(&id, |pair| pair.0)
+            .binary_search_by_key(&id, |kv| kv.track_id)
             .ok()
             // TODO: Remove bounds check.
-            .map(|idx| &slice[idx].1)
+            .map(|idx| &slice[idx].track)
     }
 
     #[inline]
     fn get_album(&self, id: AlbumId) -> Option<&Album> {
         let slice = self.album_bookmarks.range(&self.albums[..], id.for_bookmark());
         slice
-            .binary_search_by_key(&id, |pair| pair.0)
+            .binary_search_by_key(&id, |kv| kv.album_id)
             .ok()
             // TODO: Remove bounds check.
-            .map(|idx| &slice[idx].1)
+            .map(|idx| &slice[idx].album)
     }
 
     #[inline]
@@ -453,13 +452,13 @@ impl MetaIndex for MemoryMetaIndex {
     }
 
     #[inline]
-    fn get_album_tracks(&self, id: AlbumId) -> &[(TrackId, Track)] {
+    fn get_album_tracks(&self, id: AlbumId) -> &[TrackWithId] {
         // Look for track 0 of disc 0. This is the first track of the album,
         // if it exists. Otherwise binary search would find the first track
         // after it.
         let tid = TrackId::new(id, 0, 0);
         // TODO: Use bookmarks for this.
-        let begin = match self.tracks.binary_search_by_key(&tid, |pair| pair.0) {
+        let begin = match self.tracks.binary_search_by_key(&tid, |kv| kv.track_id) {
             Ok(i) => i,
             Err(i) => i,
         };
@@ -472,24 +471,24 @@ impl MetaIndex for MemoryMetaIndex {
         let next_album_tid = TrackId::new(AlbumId(id.0 + 1), 0, 0);
         let end = begin + self.tracks[begin..]
             .iter()
-            .position(|&(tid, ref _track)| tid >= next_album_tid)
+            .position(|kv| kv.track_id >= next_album_tid)
             .unwrap_or(self.tracks.len() - begin);
 
         &self.tracks[begin..end]
     }
 
     #[inline]
-    fn get_tracks(&self) -> &[(TrackId, Track)] {
+    fn get_tracks(&self) -> &[TrackWithId] {
         &self.tracks
     }
 
     #[inline]
-    fn get_albums(&self) -> &[(AlbumId, Album)] {
+    fn get_albums(&self) -> &[AlbumWithId] {
         &self.albums
     }
 
     #[inline]
-    fn get_artists(&self) -> &[(ArtistId, Artist)] {
+    fn get_artists(&self) -> &[ArtistWithId] {
         &self.artists
     }
 
@@ -497,10 +496,10 @@ impl MetaIndex for MemoryMetaIndex {
     fn get_artist(&self, id: ArtistId) -> Option<&Artist> {
         let slice = self.artist_bookmarks.range(&self.artists[..], id.0);
         slice
-            .binary_search_by_key(&id, |pair| pair.0)
+            .binary_search_by_key(&id, |kv| kv.artist_id)
             .ok()
             // TODO: Remove bounds check.
-            .map(|idx| &slice[idx].1)
+            .map(|idx| &slice[idx].artist)
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,14 @@ impl MemoryMetaIndex {
             tracks.push((id, track));
         }
 
+        // There is no easy way in Rust to guarantee that the tracks buffer is
+        // aligned (we could define a custom struct instead of the tuple, but
+        // that is rather invasive), but the allocator will give us an aligned
+        // buffer anyway at this size class. Confirm that.
+        let tracks_addr = &tracks[..].as_ptr();
+        let align_off = tracks_addr.align_offset(32);
+        assert_eq!(align_off, 0, "I was hoping that the tracks buffer would be aligned to a cache line.");
+
         for (id, album) in builder.albums.iter() {
             let (id, mut album) = (*id, album.clone());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,7 @@ impl MetaIndex for MemoryMetaIndex {
         let next_album_tid = TrackId::new(AlbumId(id.0 + 1), 0, 0);
         let end = begin + self.tracks[begin..]
             .iter()
-            .position(|&(tid, ref _track)| tid < next_album_tid)
+            .position(|&(tid, ref _track)| tid >= next_album_tid)
             .unwrap_or(self.tracks.len() - begin);
 
         &self.tracks[begin..end]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,8 @@ impl MemoryMetaIndex {
 
         MemoryMetaIndex {
             artist_bookmarks: Bookmarks::new(artists.iter().map(|p| (p.0).0)),
+            // TODO: The album bookmarks have become useless now that the album
+            // ids have their high bits all zero!
             album_bookmarks: Bookmarks::new(albums.iter().map(|p| (p.0).0)),
             track_bookmarks: Bookmarks::new(tracks.iter().map(|p| (p.0).0)),
             albums_by_artist_bookmarks: Bookmarks::new(albums_by_artist.iter().map(|p| (p.0).0)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,9 +270,13 @@ impl MemoryMetaIndex {
         // aligned (we could define a custom struct instead of the tuple, but
         // that is rather invasive), but the allocator will give us an aligned
         // buffer anyway at this size class. Confirm that.
-        let tracks_addr = &tracks[..].as_ptr();
+        // TODO: Apparently, this can be violated after all, I am getting
+        // 16-byte alignment instead of 32-byte alignment :/
+        let tracks_addr = tracks[..].as_ptr() as *const u8;
         let align_off = tracks_addr.align_offset(32);
-        assert_eq!(align_off, 0, "I was hoping that the tracks buffer would be aligned to a cache line.");
+        if align_off != 0 {
+            println!("Warning: Tracks table is not aligned to 32 bytes, this may impact performance.");
+        }
 
         for (id, album) in builder.albums.iter() {
             let (id, mut album) = (*id, album.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,7 @@ impl MetaIndex for MemoryMetaIndex {
         // access pattern.
         let end = begin + self.tracks[begin..]
             .iter()
-            .position(|&(_tid, ref track)| track.album_id != id)
+            .position(|&(tid, ref _track)| tid.album_id() != id)
             .unwrap_or(self.tracks.len() - begin);
 
         &self.tracks[begin..end]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use std::path::Path;
 
 use crate::build::{AlbumArtistsDeduper, BuildMetaIndex, BuildError};
 use crate::error::{Error, Result};
-use crate::prim::{ArtistId, Artist, AlbumArtistsRef, AlbumId, Album, TrackId, Track, Lufs, StringRef, FilenameRef, get_track_id};
+use crate::prim::{ArtistId, Artist, AlbumArtistsRef, AlbumId, Album, TrackId, Track, Lufs, StringRef, FilenameRef};
 use crate::string_utils::StringDeduper;
 use crate::word_index::MemoryWordIndex;
 
@@ -445,7 +445,7 @@ impl MetaIndex for MemoryMetaIndex {
         // Look for track 0 of disc 0. This is the first track of the album,
         // if it exists. Otherwise binary search would find the first track
         // after it.
-        let tid = get_track_id(id, 0, 0);
+        let tid = TrackId::new(id, 0, 0);
         // TODO: Use bookmarks for this.
         let begin = match self.tracks.binary_search_by_key(&tid, |pair| pair.0) {
             Ok(i) => i,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,9 +331,7 @@ impl MemoryMetaIndex {
 
         MemoryMetaIndex {
             artist_bookmarks: Bookmarks::new(artists.iter().map(|p| (p.0).0)),
-            // TODO: The album bookmarks have become useless now that the album
-            // ids have their high bits all zero!
-            album_bookmarks: Bookmarks::new(albums.iter().map(|p| (p.0).0)),
+            album_bookmarks: Bookmarks::new(albums.iter().map(|p| p.0.for_bookmark())),
             track_bookmarks: Bookmarks::new(tracks.iter().map(|p| (p.0).0)),
             albums_by_artist_bookmarks: Bookmarks::new(albums_by_artist.iter().map(|p| (p.0).0)),
             artists: artists,
@@ -437,7 +435,7 @@ impl MetaIndex for MemoryMetaIndex {
 
     #[inline]
     fn get_album(&self, id: AlbumId) -> Option<&Album> {
-        let slice = self.album_bookmarks.range(&self.albums[..], id.0);
+        let slice = self.album_bookmarks.range(&self.albums[..], id.for_bookmark());
         slice
             .binary_search_by_key(&id, |pair| pair.0)
             .ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,9 +457,10 @@ impl MetaIndex for MemoryMetaIndex {
         // 13 random memory accesses for 12k tracks, whereas most albums have
         // less tracks than that, and the linear scan has a very regular memory
         // access pattern.
+        let next_album_tid = TrackId::new(AlbumId(id.0 + 1), 0, 0);
         let end = begin + self.tracks[begin..]
             .iter()
-            .position(|&(tid, ref _track)| tid.album_id() != id)
+            .position(|&(tid, ref _track)| tid < next_album_tid)
             .unwrap_or(self.tracks.len() - begin);
 
         &self.tracks[begin..end]

--- a/src/loudness.rs
+++ b/src/loudness.rs
@@ -84,7 +84,6 @@ struct TrackResult {
 
 /// Tracks the state of loudness analysis for one track.
 struct TrackTask {
-    album_id: AlbumId,
     track_id: TrackId,
     file_id: FileId,
     path: PathBuf,
@@ -149,7 +148,7 @@ impl TrackTask {
         }).unwrap();
 
         let result = TrackResult {
-            album_id: self.album_id,
+            album_id: self.track_id.album_id(),
             meters: meters,
         };
 
@@ -384,7 +383,6 @@ impl<'a> TaskQueue<'a> {
                 .expect("We got this track from this index.");
             let fname = self.index.get_filename(track.filename);
             let task = TrackTask {
-                album_id: album_task.album_id,
                 track_id: track_id,
                 file_id: track.file_id,
                 path: PathBuf::from(fname),

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,9 @@ fn make_index(db_path: &Path) -> Result<MemoryMetaIndex> {
     );
 
     let mut track_louds = Vec::new();
-    for &(track_id, ref track) in index.get_tracks() {
-        if let Some(lufs) = track.loudness {
-            track_louds.push((lufs, track_id));
+    for kv in index.get_tracks() {
+        if let Some(lufs) = kv.track.loudness {
+            track_louds.push((lufs, kv.track_id));
         }
     }
     track_louds.sort();
@@ -77,9 +77,9 @@ fn make_index(db_path: &Path) -> Result<MemoryMetaIndex> {
     }
 
     let mut album_louds = Vec::new();
-    for &(album_id, ref album) in index.get_albums() {
-        if let Some(lufs) = album.loudness {
-            album_louds.push((lufs, album_id));
+    for kv in index.get_albums() {
+        if let Some(lufs) = kv.album.loudness {
+            album_louds.push((lufs, kv.album_id));
         }
     }
     album_louds.sort();

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn match_listens(
 
         for track_id in tracks {
             let track = index.get_track(track_id).expect("Search result should be in index.");
-            let album = index.get_album(track.album_id).expect("Track album should be in index.");
+            let album = index.get_album(track_id.album_id()).expect("Track album should be in index.");
             let track_ok = equals_normalized(index.get_string(track.title), track_title);
             let artist_ok = equals_normalized(index.get_string(track.artist), artist_name);
             let album_ok = equals_normalized(index.get_string(album.title), album_name);

--- a/src/prim.rs
+++ b/src/prim.rs
@@ -87,6 +87,7 @@ impl TrackId {
         u64::from_str_radix(src, 16).ok().map(TrackId)
     }
 
+    #[inline(always)]
     pub fn new(album_id: AlbumId, disc_number: u8, track_number: u8) -> TrackId {
         // Confirm that the numbers are in range so we don't discard anything.
         debug_assert_eq!(album_id.0 & 0xfff0_0000_0000_0000, 0);
@@ -100,14 +101,17 @@ impl TrackId {
         TrackId(id)
     }
 
+    #[inline(always)]
     pub fn track_number(&self) -> u8 {
         (self.0 & 0xff) as u8
     }
 
+    #[inline(always)]
     pub fn disc_number(&self) -> u8 {
         ((self.0 >> 8) & 0x0f) as u8
     }
 
+    #[inline(always)]
     pub fn album_id(&self) -> AlbumId {
         AlbumId(self.0 >> 12)
     }

--- a/src/prim.rs
+++ b/src/prim.rs
@@ -371,6 +371,30 @@ impl fmt::Display for ArtistId {
     }
 }
 
+/// An aligned `(TrackId, Track)` tuple.
+///
+/// Aligned to 32 bytes (same as its size) so these do not straddle cache lines.
+#[repr(align(32))]
+pub struct TrackWithId {
+    pub track_id: TrackId,
+    pub track: Track,
+}
+
+/// An `(AlbumId, Album)` tuple.
+pub struct AlbumWithId {
+    pub album_id: AlbumId,
+    pub album: Album,
+}
+
+/// An aligned `(ArtistId, Artist)` tuple.
+///
+/// Aligned to 16 bytes (same as its size) so these do not straddle cache lines.
+#[repr(align(16))]
+pub struct ArtistWithId {
+    pub artist_id: ArtistId,
+    pub artist: Artist,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -381,7 +405,12 @@ mod test {
         assert_eq!(mem::size_of::<Track>(), 24);
         assert_eq!(mem::size_of::<Album>(), 32);
         assert_eq!(mem::size_of::<Artist>(), 8);
-        assert_eq!(mem::size_of::<(TrackId, Track)>(), 32);
+
+        assert_eq!(mem::size_of::<TrackWithId>(), 32);
+        assert_eq!(mem::size_of::<ArtistWithId>(), 16);
+
+        assert_eq!(mem::size_of::<TrackWithId>(), mem::align_of::<TrackWithId>());
+        assert_eq!(mem::size_of::<ArtistWithId>(), mem::align_of::<ArtistWithId>());
 
         assert_eq!(mem::align_of::<Track>(), 8);
         assert_eq!(mem::align_of::<Album>(), 8);

--- a/src/prim.rs
+++ b/src/prim.rs
@@ -122,6 +122,16 @@ impl AlbumId {
     pub fn parse(src: &str) -> Option<AlbumId> {
         u64::from_str_radix(src, 16).ok().map(AlbumId)
     }
+
+    /// Return the album id, but shifted so the most significant byte is used.
+    ///
+    /// By default, the top 12 bits of the album id are unused, but that means
+    /// the album id is unsuiable for use with the `Bookmark` accelerator. This
+    /// resolves that.
+    #[inline(always)]
+    pub fn for_bookmark(&self) -> u64 {
+        self.0 << 12
+    }
 }
 
 impl ArtistId {

--- a/src/prim.rs
+++ b/src/prim.rs
@@ -228,9 +228,6 @@ pub struct Mtime(pub i64);
 #[repr(C)]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Track {
-    // TODO: Remove album_id, disc_number, track_number, now that we can tell
-    // from the track id.
-    pub album_id: AlbumId,
     pub file_id: FileId,
     pub title: StringRef,
     pub artist: StringRef,
@@ -243,8 +240,6 @@ pub struct Track {
     // becomes a problem, we could use some of the disc number bits to extend
     // the duration range or track number range.
     pub duration_seconds: u16,
-    pub disc_number: u8,
-    pub track_number: u8,
     pub loudness: Option<Lufs>,
 }
 
@@ -369,10 +364,10 @@ mod test {
     #[test]
     fn struct_sizes_are_as_expected() {
         use std::mem;
-        assert_eq!(mem::size_of::<Track>(), 40);
+        assert_eq!(mem::size_of::<Track>(), 24);
         assert_eq!(mem::size_of::<Album>(), 32);
         assert_eq!(mem::size_of::<Artist>(), 8);
-        assert_eq!(mem::size_of::<(TrackId, Track)>(), 48);
+        assert_eq!(mem::size_of::<(TrackId, Track)>(), 32);
 
         assert_eq!(mem::align_of::<Track>(), 8);
         assert_eq!(mem::align_of::<Album>(), 8);

--- a/src/prim.rs
+++ b/src/prim.rs
@@ -48,15 +48,28 @@ use chrono::{DateTime, Utc};
 // 0.1% at that number of artists. The lowest multiple of 8 that I can get away
 // with is 48 bits.
 
+/// The file id is a 64-bit integer assigned by SQLite.
+///
+/// File ids are not recycled, when a file changes on disk, it gets a new id.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FileId(pub i64);
 
+/// The track id is a concatenation of (album id, disc number, track number).
+///
+/// The album id is 52 bits, the disc number 4 bits, the track number 8 bits.
+/// The track number goes in the least significant bits, then the disc number,
+/// then the album id in the most significant bits.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TrackId(pub u64);
 
+/// The album id is a 52-bit id derived from the `musicbrainz_albumid` tag.
+///
+/// Only 52 bits of the id are used, such that the album id can be a prefix of
+/// the track id. The most significant 12 bits should be zero.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct AlbumId(pub u64);
 
+/// The artist (album artist) is derived form the `musicbrainz_albumartist` tag.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ArtistId(pub u64);
 
@@ -72,6 +85,31 @@ impl TrackId {
     #[inline]
     pub fn parse(src: &str) -> Option<TrackId> {
         u64::from_str_radix(src, 16).ok().map(TrackId)
+    }
+
+    pub fn new(album_id: AlbumId, disc_number: u8, track_number: u8) -> TrackId {
+        // Confirm that the numbers are in range so we don't discard anything.
+        debug_assert_eq!(album_id.0 & 0xfff0_0000_0000_0000, 0);
+        debug_assert_eq!(disc_number & 0xf0, 0);
+
+        let id = 0
+            | (album_id.0 << 12)
+            | ((disc_number as u64) << 8)
+            | (track_number as u64);
+
+        TrackId(id)
+    }
+
+    pub fn track_number(&self) -> u8 {
+        (self.0 & 0xff) as u8
+    }
+
+    pub fn disc_number(&self) -> u8 {
+        ((self.0 >> 8) & 0x0f) as u8
+    }
+
+    pub fn album_id(&self) -> AlbumId {
+        AlbumId(self.0 >> 12)
     }
 }
 
@@ -190,8 +228,8 @@ pub struct Mtime(pub i64);
 #[repr(C)]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Track {
-    // TODO: We might make the album id a true prefix of the track id, then we
-    // don't need to store the track id. Just make the album id 52 bits.
+    // TODO: Remove album_id, disc_number, track_number, now that we can tell
+    // from the track id.
     pub album_id: AlbumId,
     pub file_id: FileId,
     pub title: StringRef,
@@ -311,7 +349,10 @@ impl fmt::Display for TrackId {
 
 impl fmt::Display for AlbumId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:016x}", self.0)
+        // The upper 12 bits (3 hex digits) should be zero,
+        // so we only pad to a width of 13, not 16.
+        debug_assert_eq!(self.0 & 0xfff0_0000_0000_0000, 0);
+        write!(f, "{:013x}", self.0)
     }
 }
 
@@ -319,27 +360,6 @@ impl fmt::Display for ArtistId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:016x}", self.0)
     }
-}
-
-pub fn get_track_id(album_id: AlbumId,
-                disc_number: u8,
-                track_number: u8)
-                -> TrackId {
-    // Take the bits from the album id, so all the tracks within one album are
-    // adjacent. This is desirable, because two tracks fit in a cache line,
-    // halving the memory access cost of looking up an entire album. It also
-    // makes memory access more predictable. Finally, if the 52 most significant
-    // bits uniquely identify the album (which we assume), then all tracks are
-    // guaranteed to be adjacent, and we can use an efficient range query to
-    // find them.
-    let high = album_id.0 & 0xffff_ffff_ffff_f000;
-
-    // Finally, within an album the disc number and track number should uniquely
-    // identify the track.
-    let mid = ((disc_number & 0xf) as u64) << 8;
-    let low = track_number as u64;
-
-    TrackId(high | mid | low)
 }
 
 #[cfg(test)]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -79,8 +79,13 @@ pub fn write_album_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: AlbumId, 
     let mut first = true;
     for &(ref tid, ref track) in index.get_album_tracks(id) {
         if !first { write!(w, ",")?; }
-        write!(w, r#"{{"id":"{}","disc_number":{},"track_number":{},"title":"#,
-               tid, track.disc_number, track.track_number)?;
+        write!(
+            w,
+            r#"{{"id":"{}","disc_number":{},"track_number":{},"title":"#,
+            tid,
+            tid.disc_number(),
+            tid.track_number(),
+        )?;
         serde_json::to_writer(&mut w, index.get_string(track.title))?;
         write!(w, r#","artist":"#)?;
         serde_json::to_writer(&mut w, index.get_string(track.artist))?;
@@ -172,10 +177,15 @@ pub fn write_search_album_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: Al
 
 pub fn write_search_track_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: TrackId) -> io::Result<()> {
     let track = index.get_track(id).unwrap();
-    let album = index.get_album(track.album_id).unwrap();
+    let album_id = id.album_id();
+    let album = index.get_album(album_id).unwrap();
     write!(w, r#"{{"id":"{}","title":"#, id)?;
     serde_json::to_writer(&mut w, index.get_string(track.title))?;
-    write!(w, r#","album_id":"{}","album":"#, track.album_id)?;
+    // TODO: We might exclude the album id from the response, because it is just
+    // the suffix of the track id. It makes the response smaller, which is
+    // beneficial for sending over the network, but it also makes the format
+    // slightly more unwieldy.
+    write!(w, r#","album_id":"{}","album":"#, album_id)?;
     serde_json::to_writer(&mut w, index.get_string(album.title))?;
     write!(w, r#","artist":"#)?;
     serde_json::to_writer(&mut w, index.get_string(track.artist))?;
@@ -189,8 +199,9 @@ fn write_queued_track_json<W: Write>(
 ) -> io::Result<()> {
     // Same as the search result track format, but additionally includes
     // the duration, and playback information.
+    let album_id = queued_track.track_id.album_id();
     let track = index.get_track(queued_track.track_id).unwrap();
-    let album = index.get_album(track.album_id).unwrap();
+    let album = index.get_album(album_id).unwrap();
     write!(
         w,
         r#"{{"queue_id":"{}","track_id":"{}","title":"#,
@@ -201,7 +212,9 @@ fn write_queued_track_json<W: Write>(
     write!(
         w,
         r#","album_id":"{}","album_artist_ids":["#,
-        track.album_id,
+        // TODO: We might omit the album id, as it is a prefix of the track id,
+        // though it would make the format slightly unwieldy.
+        album_id,
     )?;
     let mut first = true;
     for artist_id in index.get_album_artists(album.artist_ids) {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -51,9 +51,9 @@ pub fn write_brief_album_json<W: Write>(
 pub fn write_albums_json<W: Write>(index: &dyn MetaIndex, mut w: W) -> io::Result<()> {
     write!(w, "[")?;
     let mut first = true;
-    for &(id, ref album) in index.get_albums() {
+    for kv in index.get_albums() {
         if !first { write!(w, ",")?; }
-        write_brief_album_json(index, &mut w, id, album)?;
+        write_brief_album_json(index, &mut w, kv.album_id, &kv.album)?;
         first = false;
     }
     write!(w, "]")
@@ -77,19 +77,20 @@ pub fn write_album_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: AlbumId, 
     serde_json::to_writer(&mut w, index.get_string(album.artist))?;
     write!(w, r#","release_date":"{}","tracks":["#, album.original_release_date)?;
     let mut first = true;
-    for &(ref tid, ref track) in index.get_album_tracks(id) {
+    for kv in index.get_album_tracks(id) {
+        let track_id = kv.track_id;
         if !first { write!(w, ",")?; }
         write!(
             w,
             r#"{{"id":"{}","disc_number":{},"track_number":{},"title":"#,
-            tid,
-            tid.disc_number(),
-            tid.track_number(),
+            track_id,
+            track_id.disc_number(),
+            track_id.track_number(),
         )?;
-        serde_json::to_writer(&mut w, index.get_string(track.title))?;
+        serde_json::to_writer(&mut w, index.get_string(kv.track.title))?;
         write!(w, r#","artist":"#)?;
-        serde_json::to_writer(&mut w, index.get_string(track.artist))?;
-        write!(w, r#","duration_seconds":{}}}"#, track.duration_seconds)?;
+        serde_json::to_writer(&mut w, index.get_string(kv.track.artist))?;
+        write!(w, r#","duration_seconds":{}}}"#, kv.track.duration_seconds)?;
         first = false;
     }
     write!(w, "]}}")

--- a/src/server.rs
+++ b/src/server.rs
@@ -104,7 +104,7 @@ impl MetaServer {
 
         let index = &*self.index_var.get();
         let tracks = index.get_album_tracks(album_id);
-        let (_track_id, track) = tracks.first().expect("Albums have at least one track.");
+        let track = &tracks.first().expect("Albums have at least one track.").track;
         let fname = index.get_filename(track.filename);
 
         let opts = claxon::FlacReaderOptions {

--- a/src/thumb_gen.rs
+++ b/src/thumb_gen.rs
@@ -273,10 +273,10 @@ pub fn generate_thumbnails(
     // Determine which albums need to have a new thumbnail extracted.
     let mut pending_tasks = Vec::new();
     let mut prev_album_id = AlbumId(0);
-    for &(_tid, ref track) in index.get_tracks() {
-        if track.album_id != prev_album_id {
+    for &(tid, ref track) in index.get_tracks() {
+        if tid.album_id() != prev_album_id {
             let fname = index.get_filename(track.filename);
-            if let Some(task) = GenThumb::new(&mut tx, track.album_id, track.file_id, fname.as_ref())? {
+            if let Some(task) = GenThumb::new(&mut tx, tid.album_id(), track.file_id, fname.as_ref())? {
                 pending_tasks.push(task);
                 status.files_to_process_thumbnails += 1;
 
@@ -284,7 +284,7 @@ pub fn generate_thumbnails(
                     status_sender.send(*status).unwrap();
                 }
             }
-            prev_album_id = track.album_id;
+            prev_album_id = tid.album_id();
         }
     }
 

--- a/src/thumb_gen.rs
+++ b/src/thumb_gen.rs
@@ -273,10 +273,12 @@ pub fn generate_thumbnails(
     // Determine which albums need to have a new thumbnail extracted.
     let mut pending_tasks = Vec::new();
     let mut prev_album_id = AlbumId(0);
-    for &(tid, ref track) in index.get_tracks() {
-        if tid.album_id() != prev_album_id {
-            let fname = index.get_filename(track.filename);
-            if let Some(task) = GenThumb::new(&mut tx, tid.album_id(), track.file_id, fname.as_ref())? {
+    for kv in index.get_tracks() {
+        let track_id = kv.track_id;
+        let album_id = track_id.album_id();
+        if album_id != prev_album_id {
+            let fname = index.get_filename(kv.track.filename);
+            if let Some(task) = GenThumb::new(&mut tx, album_id, kv.track.file_id, fname.as_ref())? {
                 pending_tasks.push(task);
                 status.files_to_process_thumbnails += 1;
 
@@ -284,7 +286,7 @@ pub fn generate_thumbnails(
                     status_sender.send(*status).unwrap();
                 }
             }
-            prev_album_id = tid.album_id();
+            prev_album_id = album_id;
         }
     }
 

--- a/tools/benchmark_server.py
+++ b/tools/benchmark_server.py
@@ -133,7 +133,7 @@ def report(f1: str, f2: str) -> None:
     #ax.axes.get_xaxis().set_visible(False)
     ax.set_xticks([])
     ax.set_xlabel("iteration")
-    ax.set_ylabel("duration")
+    ax.set_ylabel("duration (seconds)")
 
     cmap = plt.get_cmap("tab10")
     hist_bins = np.linspace(p005, p995, 25)
@@ -151,18 +151,31 @@ def report(f1: str, f2: str) -> None:
 
     ax = fig.add_subplot(gs[2, 0], sharex=x_axis)
     print(np.mean(xs))
-    bar_a = ax.barh(2.0, np.mean(xs), xerr=np.std(xs))
-    bar_b = ax.barh(1.0, np.mean(ys), xerr=np.std(ys))
+    mean_a, std_a = np.mean(xs), np.std(xs)
+    mean_b, std_b = np.mean(ys), np.std(ys)
+    bar_a = ax.barh(2.0, mean_a, xerr=std_a)
+    bar_b = ax.barh(1.0, mean_b, xerr=std_b)
     ax.set_xlim(p005, p995)
     # We don't need labels on the bars, the entire plot is color-coded.
     ax.axes.get_yaxis().set_visible(False)
-    ax.set_xlabel("duration (mean ± stddev)")
+    ax.set_xlabel("duration (seconds, mean ± stddev)")
     ax.legend([bar_a, bar_b], ["A", "B"])
 
-    fig.suptitle(f"A = {f1} vs. B = {f2}")
+    ax = fig.add_subplot(gs[0, 1])
+    ax.text(0.5, 0.66, "B duration as percentage of A:", ha="center", va="center", size=10)
+    rel_mean = mean_b / mean_a
+    rel_std = rel_mean * np.sqrt((std_a / mean_a) ** 2 + (std_b / mean_b) ** 2)
+    ax.text(0.5, 0.33, f"{rel_mean:.2%} ± {rel_std:.2%}", ha="center", va="center", size=15)
+    ax.set_axis_off()
 
+    ax = fig.add_subplot(gs[1, 1])
+    utest = stats.mannwhitneyu(xs, ys)
+    ax.text(0.5, 0.65, "H0: Samples A and B are drawn\nfrom the same distribution.", ha="center", va="center", size=10)
+    ax.text(0.5, 0.25, f"p-value: {utest.pvalue:.2g}", ha="center", va="center", size=10)
+    ax.set_axis_off()
+
+    fig.suptitle(f"A = {f1} vs. B = {f2}")
     plt.show()
-    print(stats.mannwhitneyu(xs, ys))
 
 
 if __name__ == "__main__":

--- a/tools/benchmark_server.py
+++ b/tools/benchmark_server.py
@@ -151,13 +151,15 @@ def report(f1: str, f2: str) -> None:
 
     ax = fig.add_subplot(gs[2, 0], sharex=x_axis)
     print(np.mean(xs))
-    bar_a = ax.barh(1.0, np.mean(xs), xerr=np.std(xs))
-    bar_b = ax.barh(2.0, np.mean(ys), xerr=np.std(ys))
+    bar_a = ax.barh(2.0, np.mean(xs), xerr=np.std(xs))
+    bar_b = ax.barh(1.0, np.mean(ys), xerr=np.std(ys))
     ax.set_xlim(p005, p995)
     # We don't need labels on the bars, the entire plot is color-coded.
     ax.axes.get_yaxis().set_visible(False)
     ax.set_xlabel("duration (mean ± stddev)")
     ax.legend([bar_a, bar_b], ["A", "B"])
+
+    fig.suptitle(f"A = {f1} vs. B = {f2}")
 
     plt.show()
     print(stats.mannwhitneyu(xs, ys))

--- a/tools/benchmark_server.py
+++ b/tools/benchmark_server.py
@@ -14,11 +14,12 @@ benchmark_server.py -- Benchmark Musium API server performance.
 from http.client import HTTPConnection
 from typing import List
 
+import gc
 import json
 import random
-import time
 import socket
 import sys
+import time
 
 AlbumId = str
 
@@ -53,6 +54,11 @@ def measure_get_all(albums: List[AlbumId], host: str, port: int) -> None:
     with socket.socket() as sock:
         sock.connect((host, port))
 
+        # Force a GC now, so it doesn't bother us in the middle of the
+        # measurement, should it be needed.
+        gc.collect()
+        gc.disable()
+
         t0_sec = time.monotonic()
         sock.sendall(b"".join(requests))
         while True:
@@ -63,6 +69,7 @@ def measure_get_all(albums: List[AlbumId], host: str, port: int) -> None:
                 break
 
         t1_sec = time.monotonic()
+        gc.enable()
         print(f"{t1_sec - t0_sec:.6f}")
 
 

--- a/tools/benchmark_server.py
+++ b/tools/benchmark_server.py
@@ -95,13 +95,19 @@ def report(f1: str, f2: str) -> None:
 
     fig = plt.figure(tight_layout=True)
     gs = gridspec.GridSpec(2, 2)
+
     ax = fig.add_subplot(gs[0, 0])
-    print(xs.shape, len(xs))
-    print(np.arange(0, 1, 1000).shape)
+    z = 0.5 * (np.median(xs) + np.median(ys))
+    ax.axhline(z, color="black", alpha=0.2)
     ax.scatter(np.linspace(0, 1, len(xs)), xs, s=1.5)
     ax.scatter(np.linspace(1, 2, len(ys)), ys, s=1.5)
-    plt.show()
 
+    cmap = plt.get_cmap("tab10")
+    for i, zs in enumerate([xs, ys]):
+        ax = fig.add_subplot(gs[1, i])
+        ax.hist(zs, bins=50, color=cmap(i))
+
+    plt.show()
     print(stats.mannwhitneyu(xs, ys))
 
 

--- a/tools/benchmark_server.py
+++ b/tools/benchmark_server.py
@@ -130,7 +130,6 @@ def report(f1: str, f2: str) -> None:
     ax.scatter(np.arange(len(xs), len(xs) + len(ys)), ys, s=1.3)
     # Unset the axis labels, it's just the index, this is not meaningful aside
     # from the order.
-    #ax.axes.get_xaxis().set_visible(False)
     ax.set_xticks([])
     ax.set_xlabel("iteration")
     ax.set_ylabel("duration (seconds)")
@@ -143,7 +142,13 @@ def report(f1: str, f2: str) -> None:
         zs_alt = [xs, ys][1 - i]
         ax = fig.add_subplot(gs[i, 0], sharex=x_axis)
         ax.hist(zs_now, bins=hist_bins, color=cmap(i))
-        ax.hist(zs_alt, bins=hist_bins, edgecolor=cmap(1 - i), linewidth=1.0, histtype="step")
+        ax.hist(
+            zs_alt,
+            bins=hist_bins,
+            edgecolor=cmap(1 - i),
+            linewidth=1.0,
+            histtype="step",
+        )
         # We don't need labels on the y-axis, whether it is frequency or count,
         # what matters is the shape of the distribution.
         ax.axes.get_yaxis().set_visible(False)
@@ -162,16 +167,29 @@ def report(f1: str, f2: str) -> None:
     ax.legend([bar_a, bar_b], ["A", "B"])
 
     ax = fig.add_subplot(gs[0, 1])
-    ax.text(0.5, 0.66, "B duration as percentage of A:", ha="center", va="center", size=10)
+    ax.text(
+        0.5, 0.66, "B duration as percentage of A:", ha="center", va="center", size=10
+    )
     rel_mean = mean_b / mean_a
     rel_std = rel_mean * np.sqrt((std_a / mean_a) ** 2 + (std_b / mean_b) ** 2)
-    ax.text(0.5, 0.33, f"{rel_mean:.2%} ± {rel_std:.2%}", ha="center", va="center", size=15)
+    ax.text(
+        0.5, 0.33, f"{rel_mean:.2%} ± {rel_std:.2%}", ha="center", va="center", size=15
+    )
     ax.set_axis_off()
 
     ax = fig.add_subplot(gs[1, 1])
     utest = stats.mannwhitneyu(xs, ys)
-    ax.text(0.5, 0.65, "H0: Samples A and B are drawn\nfrom the same distribution.", ha="center", va="center", size=10)
-    ax.text(0.5, 0.25, f"p-value: {utest.pvalue:.2g}", ha="center", va="center", size=10)
+    ax.text(
+        0.5,
+        0.65,
+        "H0: Samples A and B are drawn\nfrom the same distribution.",
+        ha="center",
+        va="center",
+        size=10,
+    )
+    ax.text(
+        0.5, 0.25, f"p-value: {utest.pvalue:.2g}", ha="center", va="center", size=10
+    )
     ax.set_axis_off()
 
     fig.suptitle(f"A = {f1} vs. B = {f2}")

--- a/tools/benchmark_server.py
+++ b/tools/benchmark_server.py
@@ -106,15 +106,9 @@ def report(f1: str, f2: str) -> None:
     with open(f2, encoding="ascii") as f:
         ys = np.array([float(y) for y in f])
 
-    def summarize(zs: np.ndarray) -> None:
-        m = np.mean(zs)
-        sd = np.std(zs)
-        print(f"{m:.6f} ± {sd:.6f} s")
+    plt.rcParams["font.family"] = "Source Serif Pro"
 
-    summarize(xs)
-    summarize(ys)
-
-    fig = plt.figure(tight_layout=True)
+    fig = plt.figure(tight_layout=True, figsize=(8, 7))
     gs = gridspec.GridSpec(3, 2)
 
     xs_ys = np.concatenate((xs, ys))
@@ -155,7 +149,6 @@ def report(f1: str, f2: str) -> None:
         x_axis = ax
 
     ax = fig.add_subplot(gs[2, 0], sharex=x_axis)
-    print(np.mean(xs))
     mean_a, std_a = np.mean(xs), np.std(xs)
     mean_b, std_b = np.mean(ys), np.std(ys)
     bar_a = ax.barh(2.0, mean_a, xerr=std_a)
@@ -164,7 +157,7 @@ def report(f1: str, f2: str) -> None:
     # We don't need labels on the bars, the entire plot is color-coded.
     ax.axes.get_yaxis().set_visible(False)
     ax.set_xlabel("duration (seconds, mean ± stddev)")
-    ax.legend([bar_a, bar_b], ["A", "B"])
+    ax.legend([bar_a, bar_b], ["A", "B"], loc="lower right")
 
     ax = fig.add_subplot(gs[0, 1])
     ax.text(
@@ -192,8 +185,9 @@ def report(f1: str, f2: str) -> None:
     )
     ax.set_axis_off()
 
-    fig.suptitle(f"A = {f1} vs. B = {f2}")
-    plt.show()
+    fig.suptitle(f"Benchmark Analysis\nA = {f1}  vs.  B = {f2}")
+    plt.savefig("benchmark.png", dpi=250)
+    print("Comparison saved to benchmark.png")
 
 
 if __name__ == "__main__":

--- a/tools/benchmark_server.py
+++ b/tools/benchmark_server.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Musium -- Music playback daemon with web-based library browser
+# Copyright 2023 Ruud van Asseldonk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# A copy of the License has been included in the root of the repository.
+
+"""
+benchmark_server.py -- Benchmark Musium API server performance.
+"""
+
+from http.client import HTTPConnection
+from typing import List
+
+import json
+import random
+import time
+
+AlbumId = str
+
+def load_albums(conn: HTTPConnection) -> List[AlbumId]:
+    conn.request("GET", "/api/albums")
+    albums = json.load(conn.getresponse())
+    return [album["id"] for album in albums]
+
+
+def measure_get_all(conn: HTTPConnection, albums: List[AlbumId]) -> List[float]:
+    random.shuffle(albums)
+    chunk_size = 10
+
+    for i in range(0, len(albums), chunk_size):
+        ids = albums[i:i + chunk_size]
+        t0_sec = time.monotonic()
+
+        for album_id in ids:
+            conn.request("GET", f"/api/album/{album_id}")
+            response = conn.getresponse()
+            response.read()
+            assert not response.closed
+
+        t1_sec = time.monotonic()
+        print(f"[{i:4}/{len(albums)}] {t1_sec - t0_sec:.3f}s")
+
+
+if __name__ == "__main__":
+    conn = HTTPConnection("localhost:8233")
+    albums = load_albums(conn)
+    measure_get_all(conn, albums)

--- a/tools/migrate_album_ids.py
+++ b/tools/migrate_album_ids.py
@@ -10,9 +10,109 @@
 """
 migrate_thumbnails.py -- Migrate album ids from 0.12.0 to 0.12.1.
 
-TODO
+This updates the database in-place.
 
 USAGE
 
-  tools/migrate_album_ids.py <database>
+ 1. Stop Musium 0.12.0.
+ 2. Make a back-up of your database file.
+ 3. Run 'tools/migrate_album_ids.py <db.sqlite3>'
+ 4. Start Musium 0.12.1.
 """
+
+import sqlite3
+import sys
+
+from typing import Dict, List, Tuple
+
+
+def parse_album_id_old(uuid: str) -> int:
+    high = int(uuid[:8], base=16)
+    low = int(uuid[28:], base=16)
+    return (high << 32) | low
+
+
+def parse_album_id_new(uuid: str) -> int:
+    high = int(uuid[:8], base=16)
+    low = int(uuid[31:], base=16)
+    return (high << 20) | low
+
+
+def i64_to_u64(x: int) -> int:
+    return int.from_bytes(x.to_bytes(length=8, signed=True))
+
+
+def u64_to_i64(x: int) -> int:
+    return int.from_bytes(x.to_bytes(length=8), signed=True)
+
+
+def main(db_path: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.cursor()
+
+        cur.execute(
+            """
+            select value
+            from tags
+            where field_name = 'musicbrainz_albumid';
+            """
+        )
+        mbrainz_album_ids = sorted({row[0] for row in cur.fetchall()})
+        album_id_map = {
+            parse_album_id_old(uuid): parse_album_id_new(uuid)
+            for uuid in mbrainz_album_ids
+        }
+
+        track_id_map: Dict[int, Tuple[List[int], int, int]] = {
+            id_old >> 12: ([], id_old, id_new)
+            for id_old, id_new in album_id_map.items()
+        }
+
+        cur.execute("select track_id from track_loudness")
+        for row in cur.fetchall():
+            track_id = i64_to_u64(row[0])
+            track_id_map[track_id >> 12][0].append(track_id)
+
+        tuples_album_id: List[Tuple[int, int]] = []
+        tuples_track_id: List[Tuple[int, int]] = []
+
+        for track_ids, album_id_old, album_id_new in track_id_map.values():
+            if False:
+                # Debug print, change condition to enable.
+                print(f"{album_id_old:x} -> {album_id_new:x} ({len(track_ids)} tracks)")
+            tuples_album_id.append((u64_to_i64(album_id_new), u64_to_i64(album_id_old)))
+            for track_id_old in track_ids:
+                track_id_new = (track_id_old & 0x0FFF) | (album_id_new << 12)
+                tuples_track_id.append(
+                    (u64_to_i64(track_id_new), u64_to_i64(track_id_old))
+                )
+
+        def run_update(
+            i: int, table: str, field: str, tuples: List[Tuple[int, int]]
+        ) -> None:
+            print(f"[{i}/6] Migrating table {table} ...")
+            cur.executemany(
+                f"update {table} set {field} = ? where {field} = ?;",
+                tuples,
+            )
+
+        # We do the loudness tables first, if any id conflicts (which should be
+        # rare enough for it not to happen, but it could happen in theory), that
+        # will lead to a unique key violation.
+        run_update(1, "album_loudness", "album_id", tuples_album_id)
+        run_update(2, "track_loudness", "track_id", tuples_track_id)
+        run_update(3, "listens", "album_id", tuples_album_id)
+        run_update(4, "listens", "track_id", tuples_track_id)
+        run_update(5, "thumbnails", "album_id", tuples_album_id)
+        run_update(6, "waveforms", "track_id", tuples_track_id)
+        conn.commit()
+        cur.execute("vacuum")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        main(sys.argv[1])
+
+    else:
+        print(__doc__)
+        sys.exit(1)

--- a/tools/migrate_album_ids.py
+++ b/tools/migrate_album_ids.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Musium -- Music playback daemon with web-based library browser
+# Copyright 2023 Ruud van Asseldonk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# A copy of the License has been included in the root of the repository.
+
+"""
+migrate_thumbnails.py -- Migrate album ids from 0.12.0 to 0.12.1.
+
+TODO
+
+USAGE
+
+  tools/migrate_album_ids.py <database>
+"""


### PR DESCRIPTION
## Summary

* Track ids were previously the first 52 bits of the album id, then 4 bits disc number, then 8 bits track number. But the album id was still 64 bits, so every track needed to store the album it belonged to. If we make the album id only the 52 bits, then tracks don’t need to store an id. This does create more collisions, because if album ids collided on their first 52 but not 64 bits, then the tracks in those albums would have collided anyway.
* Similarly, disc number and track number don’t need to be stored separately.
* Now a track and its id are 32 bytes, so they can align to cache lines.
* Fix a few drive-by issues (use bookmarks for album tracks lookup).
* Add scripts to benchmark the performance of the `/api/album/:album_id` endpoint.

## Benchmark results

On my 11th gen i7 laptop, the benchmark is very sensitive, it picks up differences, but also between new runs of the same binary. This suggests that despite taking measures (disable wifi, disable non-essential daemons, unplug peripherals, set scaling governor to powersave, run with taskset/ionice), I don’t have a stable enough environment to be able to measure the difference. (Quick profiling suggests that http logic and then json serialization dwarfs any time spent interacting with the album index though.)

| Measurements against the same process (stable) | Measurements against the same binary but new process (unstable) | Measurements against old vs. new binary (bogus because of instability) |
|--|--|--|
| ![benchmark](https://github.com/ruuda/musium/assets/506953/32a03215-fe3f-4849-89db-4e544c9dbfb3) | ![benchmark](https://github.com/ruuda/musium/assets/506953/26b27e80-0650-47b0-ba40-037e240872d8) | ![benchmark](https://github.com/ruuda/musium/assets/506953/3a100170-eae3-4a24-a426-5e11914a8ed8) |

On my Raspberri Pi 4, the variance in timing results is far to big to be able to detect any difference, and I cannot even get consistent results for the same process, let alone binary:

| Measurements against the same process (unstable) | Measurements against old vs. new binary |
|---|---|
| ![benchmark](https://github.com/ruuda/musium/assets/506953/726aeec8-590c-4677-b8a7-e0ba8fb65845) | ![benchmark](https://github.com/ruuda/musium/assets/506953/9fbc60a6-3a48-4fff-8b8e-fec50bf96c46) |

In any case, this does not seem to negatively impact performance while saving 16 bytes per track on memory (which can add up to megabytes, for collections with tens of thousands of tracks).