### PR TITLE
Add time embeddings, use them for sorting

### DIFF
--- a/app/src/AlbumListView.purs
+++ b/app/src/AlbumListView.purs
@@ -198,7 +198,7 @@ renderSortOptions postEvent = Html.div $ do
   let onClickPost field = Html.onClick $ void $ launchAff $ postEvent $ Event.SetSortField field
   optReleaseDate <- Html.div $ do
     Html.addClass "config-option"
-    Html.text "Release Date"
+    Html.text "Date"
     onClickPost SortReleaseDate
     ask
   optFirstSeen <- Html.div $ do
@@ -216,17 +216,23 @@ renderSortOptions postEvent = Html.div $ do
     Html.text "Trending"
     onClickPost SortTrending
     ask
+  optForNow <- Html.div $ do
+    Html.addClass "config-option"
+    Html.text "For Now"
+    onClickPost SortForNow
+    ask
 
   pure $ case _ of
     SortReleaseDate -> optReleaseDate
     SortFirstSeen   -> optFirstSeen
     SortDiscover    -> optDiscover
     SortTrending    -> optTrending
+    SortForNow      -> optForNow
 
 setSortMode :: SortMode -> AlbumListView -> Effect Unit
 setSortMode { field, direction } state =
   let
-    allFields = [SortReleaseDate, SortFirstSeen, SortDiscover, SortTrending]
+    allFields = [SortReleaseDate, SortFirstSeen, SortDiscover, SortTrending, SortForNow]
     unsort = do
       Html.removeClass "increasing"
       Html.removeClass "decreasing"

--- a/app/src/Event.purs
+++ b/app/src/Event.purs
@@ -26,6 +26,7 @@ data SortField
   | SortFirstSeen
   | SortDiscover
   | SortTrending
+  | SortForNow
 
 derive instance sortFieldEq :: Eq SortField
 

--- a/app/src/Model.purs
+++ b/app/src/Model.purs
@@ -140,6 +140,7 @@ newtype Album = Album
   , firstSeen :: String
   , discoverScore :: Number
   , trendingScore :: Number
+  , forNowScore :: Number
   }
 
 instance decodeJsonAlbum :: DecodeJson Album where
@@ -156,6 +157,7 @@ instance decodeJsonAlbum :: DecodeJson Album where
     firstSeen     <- Json.getField obj "first_seen"
     discoverScore <- Json.getField obj "discover_score"
     trendingScore <- Json.getField obj "trending_score"
+    forNowScore <- Json.getField obj "for_now_score"
     pure $ Album
       { id
       , title
@@ -165,6 +167,7 @@ instance decodeJsonAlbum :: DecodeJson Album where
       , firstSeen
       , discoverScore
       , trendingScore
+      , forNowScore
       }
 
 getAlbums :: Aff (Array Album)

--- a/app/src/State.purs
+++ b/app/src/State.purs
@@ -317,6 +317,7 @@ sortAlbums {field, direction} albums =
       SortFirstSeen   -> Array.sortWith (\(Album album) -> album.firstSeen)     albums
       SortDiscover    -> Array.sortWith (\(Album album) -> album.discoverScore) albums
       SortTrending    -> Array.sortWith (\(Album album) -> album.trendingScore) albums
+      SortForNow      -> Array.sortWith (\(Album album) -> album.forNowScore)   albums
 
 toggleSortDirection :: SortDirection -> SortDirection
 toggleSortDirection = case _ of

--- a/app/style.css
+++ b/app/style.css
@@ -99,11 +99,16 @@ body {
   display: none;
 }
 
+.list-config {
+  white-space: nowrap;
+  overflow: hidden;
+}
+
 .list-config .config-option {
   display: inline-block;
   height: 1.5rem;
   line-height: 1.5rem;
-  padding: 1rem;
+  padding: 0.9rem;
   padding-bottom: 0;
   padding-top: 0;
   margin-top: 1rem;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,10 +22,18 @@ Musium versions are named `MAJOR.MINOR.PATCH`.
 
 ## Next
 
- * The ranking behind the _discover_ sort mode now better balances past and
-   recent popularity to show you albums worth listening to again.
+ * A new sort option is available in the album list: _For Now_. This ranking
+   shows you albums that you played at similar times of the day, week, and year
+   in the past. For example, if you tend to listen to more quiet music in the
+   morning, and more intense music on Friday nights, this will surface those
+   albums at the right times.
+ * The ranking behind the _Discover_ sort mode now better balances past and
+   recent popularity to show you albums worth listening to again. Like the
+   _For Now_ ranking, it takes into account the time of the day, week, and year,
+   to show the most relevant suggestions.
  * The queue tab in the webinterface is now implemented, including buttons to
    shuffle and clear the queue.
+ * Add support for Czech diacritics in text normalization.
 
 ## 0.16.0
 

--- a/src/playcount.rs
+++ b/src/playcount.rs
@@ -348,21 +348,6 @@ impl Default for TimeVector {
     }
 }
 
-impl std::ops::Add<TimeVector> for TimeVector {
-    type Output = TimeVector;
-
-    fn add(self, rhs: TimeVector) -> TimeVector {
-        TimeVector([
-            self.0[0] + rhs.0[0],
-            self.0[1] + rhs.0[1],
-            self.0[2] + rhs.0[2],
-            self.0[3] + rhs.0[3],
-            self.0[4] + rhs.0[4],
-            self.0[5] + rhs.0[5],
-        ])
-    }
-}
-
 impl std::ops::Mul<f32> for TimeVector {
     type Output = TimeVector;
 

--- a/src/playcount.rs
+++ b/src/playcount.rs
@@ -11,12 +11,12 @@ use std::collections::BinaryHeap;
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::album_table::AlbumTable;
 use crate::database::{self, Transaction};
 use crate::database_utils::connect_readonly;
 use crate::prim::{AlbumId, ArtistId, TrackId};
-use crate::{MemoryMetaIndex, MetaIndex};
-use crate::album_table::AlbumTable;
 use crate::user_data::AlbumState;
+use crate::{MemoryMetaIndex, MetaIndex};
 
 /// A point in time with second granularity.
 ///
@@ -282,9 +282,9 @@ impl ExpCounter {
         19260.0, // 3650 days / 10 years
         // 9630.615234, // 1826 days / 5 years
         2407.653809, // 457 days / 1.25 years
-        601.913452, // 114 days / ~3.75 months / 16 weeks
-        150.478363, // 29 days / 1 month
-        37.619591, // 7 days
+        601.913452,  // 114 days / ~3.75 months / 16 weeks
+        150.478363,  // 29 days / 1 month
+        37.619591,   // 7 days
     ];
 
     /// Return how much to decay the counters by after the elapsed time.
@@ -669,10 +669,7 @@ fn print_ranking(
 /// playcount on a short timescale, while still mixing in a bit of a longer
 /// time horizon.
 fn score_trending(counter: &ExpCounter) -> f32 {
-    0.0
-    + (2.0 * counter.n[4])
-    + (0.5 * counter.n[3])
-    + (0.1 * counter.n[2])
+    (2.0 * counter.n[4]) + (0.5 * counter.n[3]) + (0.1 * counter.n[2])
 }
 
 /// Score for sorting entries by _falling_.
@@ -718,7 +715,10 @@ pub fn main(index: &MemoryMetaIndex, db_path: &Path) -> crate::Result<()> {
             counts.get_top_by(150, |counter: &ExpCounter| RevNotNan(counter.n[timescale]));
         print_ranking(
             "TOP",
-            format!("timescale {}, {:.0} days / {:.0} months", timescale, n_days, n_months),
+            format!(
+                "timescale {}, {:.0} days / {:.0} months",
+                timescale, n_days, n_months
+            ),
             index,
             &top_artists,
             &top_albums,
@@ -737,7 +737,8 @@ pub fn main(index: &MemoryMetaIndex, db_path: &Path) -> crate::Result<()> {
         &trending_tracks,
     );
 
-    let (falling_artists, falling_albums, falling_tracks) = counts.get_top_by(350, |c| RevNotNan(score_falling(c)));
+    let (falling_artists, falling_albums, falling_tracks) =
+        counts.get_top_by(350, |c| RevNotNan(score_falling(c)));
     print_ranking(
         "FALLING",
         "see code for formula".to_string(),

--- a/src/playcount.rs
+++ b/src/playcount.rs
@@ -192,7 +192,7 @@ pub struct RateLimit {
 /// vs. evening, or weekend vs. weekday, or summer vs. winter. Based on this we
 /// hope to suggest better tracks to listen to based on the current moment. E.g.
 /// in the early morning we may suggest some chill jazz but not heavy dancefloor
-/// banger.
+/// bangers.
 ///
 /// Because years, weeks, and days are all cyclic, we treat them as circles, and
 /// we embed the moment as x, y coordinate on the circle. This ensures that
@@ -221,7 +221,7 @@ pub struct RateLimit {
 ///
 /// ## Normalization
 ///
-/// When we embed an instant, the length of the vector is 3. Each of the
+/// When we embed an instant, the length of the vector is sqrt(3). Each of the
 /// 3 components (year/week/day) has a length of 1 by construction, so the
 /// relative length of the components is equal. After adding time vectors
 /// together, this is no longer true. For example, if we listen a track on every
@@ -317,12 +317,12 @@ impl TimeVector {
         ];
 
         // The length of the embedding vector of an instant is by construction
-        // 3.0, and restricted to the year/week/day part, each of those parts
-        // has length 1.0. But when we add those embeddings together, the ones
-        // that point in the same direction reinforce while ones that point in
-        // different directions cancel out. So we play a track on every day of
-        // the week in one month, the year part becomes longer relative to the
-        // week part. We print those weights to classify an item in which of
+        // sqrt(3.0), and restricted to the year/week/day part, each of those
+        // parts has length 1.0. But when we add those embeddings together, the
+        // ones that point in the same direction reinforce while ones that point
+        // in different directions cancel out. So we play a track on every day
+        // of the week in one month, the year part becomes longer relative to
+        // the week part. We print those weights to classify an item in which of
         // these three cycles it is most seasonal.
         let w2_year = self.0[0] * self.0[0] + self.0[1] * self.0[1];
         let w2_week = self.0[2] * self.0[2] + self.0[3] * self.0[3];

--- a/src/playcount.rs
+++ b/src/playcount.rs
@@ -778,6 +778,7 @@ impl PlayCounts {
             let state = AlbumState {
                 discover_score: score_falling(counter),
                 trending_score: score_trending(counter),
+                top_score: score_top(counter),
                 time_embedding: counter.time_embedding,
             };
             albums.insert(*album_id, state);
@@ -855,6 +856,13 @@ fn print_ranking(
 /// time horizon.
 fn score_trending(counter: &ExpCounter) -> f32 {
     (2.0 * counter.n[4]) + (0.5 * counter.n[3]) + (0.1 * counter.n[2])
+}
+
+/// Score for sorting by top.
+///
+/// This is a mix of the longest two time scales.
+fn score_top(counter: &ExpCounter) -> f32 {
+    counter.n[0].ln() + counter.n[1].ln()
 }
 
 /// Score for sorting entries by _falling_.

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -42,7 +42,7 @@ pub fn write_brief_album_json<W: Write>(
     }
     write!(w, r#"],"artist":"#)?;
     serde_json::to_writer(&mut w, index.get_string(album.artist))?;
-    let scores = user_data.get_album_scores(album_id).score(now_embed);
+    let scores = user_data.get_album_scores(album_id, now_embed);
     write!(
         w,
         // The discover score can have large-ish magnitude and ranges from negative
@@ -315,17 +315,16 @@ pub fn write_queue_json<W: Write>(
     write!(w, "[")?;
     let mut first = true;
     for queued_track in tracks.iter() {
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write_queued_track_json(index, user_data, &mut w, queued_track)?;
         first = false;
     }
     write!(w, "]")
 }
 
-pub fn write_player_params_json<W: Write>(
-    mut w: W,
-    params: &Params,
-) -> io::Result<()> {
+pub fn write_player_params_json<W: Write>(mut w: W, params: &Params) -> io::Result<()> {
     write!(
         w,
         r#"{{"volume_db":{:.02},"high_pass_cutoff_hz":{}}}"#,

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -12,6 +12,7 @@ use serde_json;
 use std::io;
 use std::io::Write;
 
+use crate::playcount::TimeVector;
 use crate::player::{Params, TrackSnapshot};
 use crate::scan;
 use crate::user_data::UserData;
@@ -23,6 +24,7 @@ use crate::{Album, AlbumId, Artist, ArtistId, MetaIndex, TrackId};
 pub fn write_brief_album_json<W: Write>(
     index: &dyn MetaIndex,
     user_data: &UserData,
+    now_embed: &TimeVector,
     mut w: W,
     album_id: AlbumId,
     album: &Album,
@@ -32,24 +34,27 @@ pub fn write_brief_album_json<W: Write>(
     write!(w, r#","artist_ids":["#)?;
     let mut first = true;
     for artist_id in index.get_album_artists(album.artist_ids) {
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write!(w, r#""{}""#, artist_id)?;
         first = false;
     }
     write!(w, r#"],"artist":"#)?;
     serde_json::to_writer(&mut w, index.get_string(album.artist))?;
-    let scores = user_data.get_album_scores(album_id);
+    let scores = user_data.get_album_scores(album_id).score(now_embed);
     write!(
         w,
         // The discover score can have large-ish magnitude and ranges from negative
         // to positive, it does not need a lot of precision. The trending score
         // is always between 0 and 1 though, it needs more digits for precision
         // near the end of the ranking.
-        r#","release_date":"{}","first_seen":"{}","discover_score":{:.2},"trending_score":{:.4}}}"#,
+        r#","release_date":"{}","first_seen":"{}","discover_score":{:.2},"trending_score":{:.4},"for_now_score":{:.3}}}"#,
         album.original_release_date,
         album.first_seen.format_iso8601(),
-        scores.discover_score,
-        scores.trending_score,
+        scores.discover,
+        scores.trending,
+        scores.for_now,
     )?;
     Ok(())
 }
@@ -58,13 +63,16 @@ pub fn write_brief_album_json<W: Write>(
 pub fn write_albums_json<W: Write>(
     index: &dyn MetaIndex,
     user_data: &UserData,
+    now_embed: &TimeVector,
     mut w: W,
 ) -> io::Result<()> {
     write!(w, "[")?;
     let mut first = true;
     for kv in index.get_albums() {
-        if !first { write!(w, ",")?; }
-        write_brief_album_json(index, user_data, &mut w, kv.album_id, &kv.album)?;
+        if !first {
+            write!(w, ",")?;
+        }
+        write_brief_album_json(index, user_data, now_embed, &mut w, kv.album_id, &kv.album)?;
         first = false;
     }
     write!(w, "]")
@@ -86,17 +94,25 @@ pub fn write_album_json<W: Write>(
     write!(w, r#","artist_ids":["#)?;
     let mut first = true;
     for artist_id in index.get_album_artists(album.artist_ids) {
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write!(w, r#""{}""#, artist_id)?;
         first = false;
     }
     write!(w, r#"],"artist":"#)?;
     serde_json::to_writer(&mut w, index.get_string(album.artist))?;
-    write!(w, r#","release_date":"{}","tracks":["#, album.original_release_date)?;
+    write!(
+        w,
+        r#","release_date":"{}","tracks":["#,
+        album.original_release_date
+    )?;
     let mut first = true;
     for kv in index.get_album_tracks(id) {
         let track_id = kv.track_id;
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write!(
             w,
             r#"{{"id":"{}","disc_number":{},"track_number":{},"title":"#,
@@ -122,6 +138,7 @@ pub fn write_album_json<W: Write>(
 pub fn write_artist_json<W: Write>(
     index: &dyn MetaIndex,
     user_data: &UserData,
+    now_embed: &TimeVector,
     mut w: W,
     artist: &Artist,
     albums: &[(ArtistId, AlbumId)],
@@ -137,8 +154,10 @@ pub fn write_artist_json<W: Write>(
         // well-formed, it will never fail. The id is provided by the index
         // itself, not user input, so the album should be present.
         let album = index.get_album(album_id).unwrap();
-        if !first { write!(w, ",")?; }
-        write_brief_album_json(index, user_data, &mut w, album_id, album)?;
+        if !first {
+            write!(w, ",")?;
+        }
+        write_brief_album_json(index, user_data, now_embed, &mut w, album_id, album)?;
         first = false;
     }
     write!(w, "]}}")
@@ -154,28 +173,38 @@ pub fn write_search_results_json<W: Write>(
     write!(w, r#"{{"artists":["#)?;
     let mut first = true;
     for &aid in artists {
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write_search_artist_json(index, &mut w, aid)?;
         first = false;
     }
     write!(w, r#"],"albums":["#)?;
     let mut first = true;
     for &aid in albums {
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write_search_album_json(index, &mut w, aid)?;
         first = false;
     }
     write!(w, r#"],"tracks":["#)?;
     let mut first = true;
     for &tid in tracks {
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write_search_track_json(index, &mut w, tid)?;
         first = false;
     }
     write!(w, r#"]}}"#)
 }
 
-pub fn write_search_artist_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: ArtistId) -> io::Result<()> {
+pub fn write_search_artist_json<W: Write>(
+    index: &dyn MetaIndex,
+    mut w: W,
+    id: ArtistId,
+) -> io::Result<()> {
     let artist = index.get_artist(id).unwrap();
     let albums = index.get_albums_by_artist(id);
     write!(w, r#"{{"id":"{}","name":"#, id)?;
@@ -183,14 +212,20 @@ pub fn write_search_artist_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: A
     write!(w, r#","albums":["#)?;
     let mut first = true;
     for &(_artist_id, album_id) in albums {
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write!(w, r#""{}""#, album_id)?;
         first = false;
     }
     write!(w, r#"]}}"#)
 }
 
-pub fn write_search_album_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: AlbumId) -> io::Result<()> {
+pub fn write_search_album_json<W: Write>(
+    index: &dyn MetaIndex,
+    mut w: W,
+    id: AlbumId,
+) -> io::Result<()> {
     let album = index.get_album(id).unwrap();
     write!(w, r#"{{"id":"{}","title":"#, id)?;
     serde_json::to_writer(&mut w, index.get_string(album.title))?;
@@ -199,7 +234,11 @@ pub fn write_search_album_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: Al
     write!(w, r#","release_date":"{}"}}"#, album.original_release_date)
 }
 
-pub fn write_search_track_json<W: Write>(index: &dyn MetaIndex, mut w: W, id: TrackId) -> io::Result<()> {
+pub fn write_search_track_json<W: Write>(
+    index: &dyn MetaIndex,
+    mut w: W,
+    id: TrackId,
+) -> io::Result<()> {
     let track = index.get_track(id).unwrap();
     let album_id = id.album_id();
     let album = index.get_album(album_id).unwrap();
@@ -230,8 +269,7 @@ fn write_queued_track_json<W: Write>(
     write!(
         w,
         r#"{{"queue_id":"{}","track_id":"{}","title":"#,
-        queued_track.queue_id,
-        queued_track.track_id,
+        queued_track.queue_id, queued_track.track_id,
     )?;
     serde_json::to_writer(&mut w, index.get_string(track.title))?;
     write!(
@@ -243,7 +281,9 @@ fn write_queued_track_json<W: Write>(
     )?;
     let mut first = true;
     for artist_id in index.get_album_artists(album.artist_ids) {
-        if !first { write!(w, ",")?; }
+        if !first {
+            write!(w, ",")?;
+        }
         write!(w, r#""{}""#, artist_id)?;
         first = false;
     }
@@ -265,7 +305,6 @@ fn write_queued_track_json<W: Write>(
     write!(w, r#","buffered_seconds":{:.03}"#, buffered_seconds)?;
     write!(w, r#","is_buffering":{}}}"#, queued_track.is_buffering)
 }
-
 
 pub fn write_queue_json<W: Write>(
     index: &dyn MetaIndex,
@@ -318,7 +357,8 @@ pub fn write_scan_status_json<W: Write>(
         ScanStage::Done => "done",
     };
 
-    write!(w,
+    write!(
+        w,
         "{{\
         \"stage\":\"{}\",\
         \"files_discovered\":{},\
@@ -345,11 +385,9 @@ pub fn write_scan_status_json<W: Write>(
 }
 
 /// Write library statistics as json.
-pub fn write_stats_json<W: Write>(
-    index: &dyn MetaIndex,
-    mut w: W,
-) -> io::Result<()> {
-    write!(w,
+pub fn write_stats_json<W: Write>(index: &dyn MetaIndex, mut w: W) -> io::Result<()> {
+    write!(
+        w,
         "{{\
         \"tracks\":{},\
         \"albums\":{},\

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,7 +38,9 @@ fn header_content_type(content_type: &str) -> Header {
 
 fn header_expires_seconds(age_seconds: i64) -> Header {
     let now = chrono::Utc::now();
-    let at = now.checked_add_signed(chrono::Duration::seconds(age_seconds)).unwrap();
+    let at = now
+        .checked_add_signed(chrono::Duration::seconds(age_seconds))
+        .unwrap();
     // The format from https://tools.ietf.org/html/rfc7234#section-5.3.
     let value = at.format("%a, %e %b %Y %H:%M:%S GMT").to_string();
     Header::from_bytes(&b"Expires"[..], value)
@@ -68,10 +70,7 @@ impl MetaServer {
             thumb_cache_var: thumb_cache_var.clone(),
             user_data: user_data,
             player: player,
-            scanner: BackgroundScanner::new(
-                index_var,
-                thumb_cache_var,
-            ),
+            scanner: BackgroundScanner::new(index_var, thumb_cache_var),
         }
     }
 
@@ -111,7 +110,10 @@ impl MetaServer {
 
         let index = &*self.index_var.get();
         let tracks = index.get_album_tracks(album_id);
-        let track = &tracks.first().expect("Albums have at least one track.").track;
+        let track = &tracks
+            .first()
+            .expect("Albums have at least one track.")
+            .track;
         let fname = index.get_filename(track.filename);
 
         let opts = claxon::FlacReaderOptions {
@@ -166,13 +168,11 @@ impl MetaServer {
             None => return self.handle_bad_request("Invalid track id."),
         };
 
-        let waveform = db
-            .begin()
-            .and_then(|mut tx| {
-                let result = db::select_track_waveform(&mut tx, track_id.0 as i64)?;
-                tx.commit()?;
-                Ok(result)
-            });
+        let waveform = db.begin().and_then(|mut tx| {
+            let result = db::select_track_waveform(&mut tx, track_id.0 as i64)?;
+            tx.commit()?;
+            Ok(result)
+        });
 
         let waveform = match waveform {
             Ok(Some(data)) => Waveform::from_bytes(data),
@@ -184,7 +184,9 @@ impl MetaServer {
         };
 
         let mut svg = Vec::new();
-        waveform.write_svg(&mut svg).expect("Write to memory does not fail.");
+        waveform
+            .write_svg(&mut svg)
+            .expect("Write to memory does not fail.");
 
         Response::from_data(svg)
             .with_header(header_content_type("image/svg+xml"))
@@ -195,7 +197,7 @@ impl MetaServer {
     fn handle_track(&self, path: &str) -> ResponseBox {
         // Track urls are of the form `/track/f7c153f2b16dc101.flac`.
         if !path.ends_with(".flac") {
-            return self.handle_bad_request("Expected a path ending in .flac.")
+            return self.handle_bad_request("Expected a path ending in .flac.");
         }
 
         let id_part = &path[..path.len() - ".flac".len()];
@@ -246,7 +248,8 @@ impl MetaServer {
             &mut w,
             album_id,
             album,
-        ).unwrap();
+        )
+        .unwrap();
 
         Response::from_data(w.into_inner())
             .with_header(header_content_type("application/json"))
@@ -338,7 +341,8 @@ impl MetaServer {
             &self.user_data.lock().unwrap(),
             &mut w,
             &queue.tracks[..],
-        ).unwrap();
+        )
+        .unwrap();
         Response::from_data(w.into_inner())
             .with_header(header_content_type("application/json"))
             .boxed()
@@ -423,7 +427,7 @@ impl MetaServer {
             if k == "q" {
                 opt_query = Some(v);
             }
-        };
+        }
         let query = match opt_query {
             Some(q) => q,
             None => return self.handle_bad_request("Missing search query."),
@@ -458,7 +462,8 @@ impl MetaServer {
             &artists[..n_artists],
             &albums[..n_albums],
             &tracks[..n_tracks],
-        ).unwrap();
+        )
+        .unwrap();
 
         Response::from_data(w.into_inner())
             .with_status_code(200)
@@ -502,6 +507,7 @@ impl MetaServer {
     }
 
     /// Router function for all /api/«endpoint» calls.
+    #[rustfmt::skip]
     fn handle_api_request(
         &self,
         db: &mut Connection,
@@ -580,6 +586,7 @@ impl MetaServer {
         let query = url_iter.next().unwrap_or("");
 
         // A very basic router. See also docs/api.md for an overview.
+        #[rustfmt::skip]
         let response = match (request.method(), p0, p1) {
             // API endpoints go through the API router, to keep this match arm
             // a bit more concise.
@@ -630,21 +637,23 @@ pub fn serve(bind: &str, service: Arc<MetaServer>) -> ! {
         let service_i = service.clone();
         let name = format!("http_server_{}", i);
         let builder = thread::Builder::new().name(name);
-        let join_handle = builder.spawn(move || {
-            let connection = database_utils::connect_readonly(&service_i.config.db_path)
-                .expect("Failed to connect to database.");
-            let mut db = Connection::new(&connection);
-            loop {
-                let request = match server_i.recv() {
-                    Ok(rq) => rq,
-                    Err(e) => {
-                        println!("Error: {:?}", e);
-                        break;
-                    }
-                };
-                service_i.handle_request(&mut db, request);
-            }
-        }).unwrap();
+        let join_handle = builder
+            .spawn(move || {
+                let connection = database_utils::connect_readonly(&service_i.config.db_path)
+                    .expect("Failed to connect to database.");
+                let mut db = Connection::new(&connection);
+                loop {
+                    let request = match server_i.recv() {
+                        Ok(rq) => rq,
+                        Err(e) => {
+                            println!("Error: {:?}", e);
+                            break;
+                        }
+                    };
+                    service_i.handle_request(&mut db, request);
+                }
+            })
+            .unwrap();
         threads.push(join_handle);
     }
 

--- a/src/user_data.rs
+++ b/src/user_data.rs
@@ -84,6 +84,15 @@ pub struct AlbumState {
     // Playcount on the shortest timescale.
     pub trending_score: f32,
 
+    // Log playcount on the longer timescales.
+    //
+    // Could be used directly to sort by top albums, but in the UI this is not
+    // _that_ useful. Instead, we can mix it with the time embedding to provide
+    // a list of "for now" albums for this time of the day, where we don't
+    // suggest albums with a low playcount just because the one time we played
+    // them was at this time of the day.
+    pub top_score: f32,
+
     // Vector embedding of the play times, used to weigh the discover score.
     pub time_embedding: TimeVector,
 }

--- a/src/user_data.rs
+++ b/src/user_data.rs
@@ -93,7 +93,9 @@ pub struct AlbumState {
     // them was at this time of the day.
     pub score_longterm: f32,
 
-    // Vector embedding of the play times, used to weigh the discover score.
+    // Vector embedding of the play times.
+    //
+    // Used to weigh the discover score, and compute the "for now" score.
     pub time_embedding: TimeVector,
 }
 


### PR DESCRIPTION
## Background

An idea that I've had for a very long time, and I now finally got to implementing: music is very seasonal for me, on multiple levels. Some albums are good for a hot summer night, while others are good for a rainy autumn day. I listen to more chill music early in the morning, more upbeat music during the day and evening. I listen to different music on weekends than on weekdays.

All of these are cyclic, all of them have a “center” modulo a year, week, and day. So what if we generate vectors, and embed these points in time in ℝ⁶ (technically, S¹×S¹×S¹ embedded in ℝ⁶)? Then adding/averaging them becomes meaningful, and every track, album, and artist can have a “preferred time”. We can use cosine distance to find albums suitable for the current time of the day/week/year.

So I implemented this. It works. It works surprisingly well, actually. I planned to use this as one feature to feed into a neural network, but even the basic cosine distance works quite well.

## Performance impact

It sounds kind of expensive to do all these float operations on every listen when replaying the history, and to recompute the score on every request, however it seems fine. On my (reasonably fast) laptop, `musium count` — which runs the count for the entire history in the database and then ranks in various ways — runs in 280 ms with 45k listens, and it’s probably not even bottlenecked on these new operations. On my Raspberry Pi 4, loading playcounts takes less than a second (the logs only have second granularity), and curling the `/api/albums` endpoint locally on the Raspberry takes 40.6 ms ± 7.3 ms, so nothing to worry about. Memory usage grows too in theory, but I observe 51–54MB at idle for my collection both before and after, so this is not a problem either.